### PR TITLE
Adding Microsoft Live Share extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 					"*.md": "vscode.markdown.preview.editor"
 				}
 			},
-			"extensions": ["cweijan.vscode-database-client2"]
+			"extensions": ["cweijan.vscode-database-client2", "MS-vsliveshare.vsliveshare"]
 		}
 	},
 


### PR DESCRIPTION
This change will allow students to share running workspaces with teachers and mentors when asking for assistance.